### PR TITLE
Upgrade libraries com.typesafe.akka

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,7 +9,7 @@ licenses += ("MIT", url("http://opensource.org/licenses/MIT"))
 
 resolvers += "Artifactory" at "https://flow.jfrog.io/flow/libs-release/"
 
-lazy val akkaVersion = "2.6.1"
+lazy val akkaVersion = "2.6.4"
 
 libraryDependencies ++= Seq(
   "com.iheart" %% "ficus" % "1.4.7",


### PR DESCRIPTION
- com.typesafe.akka
  - akka-actor (2.6.1 => 2.6.4)
  - akka-slf4j (2.6.1 => 2.6.4)
  - akka-testkit (2.6.1 => 2.6.4)