### PR TITLE
Upgrade libraries io.flow, org.scalatest

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -17,15 +17,15 @@ lazy val akkaVersion = "2.6.3"
 
 libraryDependencies ++= Seq(
   "com.iheart" %% "ficus" % "1.4.7",
-  "io.flow" %% s"lib-log" % "0.1.16",
+  "io.flow" %% s"lib-log" % "0.1.17",
   "com.typesafe.akka" %% "akka-actor" % akkaVersion % Provided,
   "com.typesafe.akka" %% "akka-slf4j" % akkaVersion % Provided,
   "com.typesafe.play" %% "play-json" % "2.9.0" % Provided,
   "com.typesafe.akka" %% "akka-testkit" % akkaVersion % Test,
   "org.mockito" % "mockito-all" % "1.10.19" % Test,
-  "org.scalatest" %% "scalatest" % "3.2.0" % Test,
-  "org.scalatest" %% "scalatest-mustmatchers" % "3.2.0" % Test,
-  "org.scalatest" %% "scalatest-wordspec" % "3.2.0" % Test,
+  "org.scalatest" %% "scalatest" % "3.2.1" % Test,
+  "org.scalatest" %% "scalatest-mustmatchers" % "3.2.1" % Test,
+  "org.scalatest" %% "scalatest-wordspec" % "3.2.1" % Test,
 )
 
 scalacOptions in (Compile, doc) ++= Seq(


### PR DESCRIPTION
- io.flow
  - lib-log (0.1.16 => 0.1.17)
- org.scalatest
  - scalatest (3.2.0 => 3.2.1)
  - scalatest-mustmatchers (3.2.0 => 3.2.1)
  - scalatest-wordspec (3.2.0 => 3.2.1)