### PR TITLE
Upgrade libraries

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -17,15 +17,15 @@ lazy val akkaVersion = "2.6.3"
 
 libraryDependencies ++= Seq(
   "com.iheart" %% "ficus" % "1.4.7",
-  "io.flow" %% s"lib-log" % "0.1.19",
+  "io.flow" %% s"lib-log" % "0.1.20",
   "com.typesafe.akka" %% "akka-actor" % akkaVersion % Provided,
   "com.typesafe.akka" %% "akka-slf4j" % akkaVersion % Provided,
-  "com.typesafe.play" %% "play-json" % "2.9.0" % Provided,
+  "com.typesafe.play" %% "play-json" % "2.9.1" % Provided,
   "com.typesafe.akka" %% "akka-testkit" % akkaVersion % Test,
   "org.mockito" % "mockito-all" % "1.10.19" % Test,
-  "org.scalatest" %% "scalatest" % "3.2.1" % Test,
-  "org.scalatest" %% "scalatest-mustmatchers" % "3.2.1" % Test,
-  "org.scalatest" %% "scalatest-wordspec" % "3.2.1" % Test,
+  "org.scalatest" %% "scalatest" % "3.2.2" % Test,
+  "org.scalatest" %% "scalatest-mustmatchers" % "3.2.2" % Test,
+  "org.scalatest" %% "scalatest-wordspec" % "3.2.2" % Test,
 )
 
 scalacOptions in (Compile, doc) ++= Seq(


### PR DESCRIPTION
- com.typesafe.play
  - play-json (2.9.0 => 2.9.1)
- io.flow
  - lib-log (0.1.19 => 0.1.20)
- org.scalatest
  - scalatest (3.2.1 => 3.2.2)
  - scalatest-mustmatchers (3.2.1 => 3.2.2)
  - scalatest-wordspec (3.2.1 => 3.2.2)