### PR TITLE
Upgrade libraries org.scalatest

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -23,9 +23,9 @@ libraryDependencies ++= Seq(
   "com.typesafe.play" %% "play-json" % "2.9.2" % Provided,
   "com.typesafe.akka" %% "akka-testkit" % akkaVersion % Test,
   "org.mockito" % "mockito-all" % "1.10.19" % Test,
-  "org.scalatest" %% "scalatest" % "3.2.6" % Test,
-  "org.scalatest" %% "scalatest-mustmatchers" % "3.2.6" % Test,
-  "org.scalatest" %% "scalatest-wordspec" % "3.2.6" % Test,
+  "org.scalatest" %% "scalatest" % "3.2.7" % Test,
+  "org.scalatest" %% "scalatest-mustmatchers" % "3.2.7" % Test,
+  "org.scalatest" %% "scalatest-wordspec" % "3.2.7" % Test,
 )
 
 scalacOptions in (Compile, doc) ++= Seq(


### PR DESCRIPTION
- org.scalatest
  - scalatest (3.2.6 => 3.2.7)
  - scalatest-mustmatchers (3.2.6 => 3.2.7)
  - scalatest-wordspec (3.2.6 => 3.2.7)