### PR TITLE
Upgrade libraries

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -27,16 +27,16 @@ resolvers += "Artifactory" at "https://flow.jfrog.io/flow/libs-release/"
 lazy val akkaVersion = "2.6.3"
 
 libraryDependencies ++= Seq(
-  "com.iheart" %% "ficus" % "1.5.0",
-  "io.flow" %% s"lib-log" % "0.1.47",
+  "com.iheart" %% "ficus" % "1.5.1",
+  "io.flow" %% s"lib-log" % "0.1.48",
   "com.typesafe.akka" %% "akka-actor" % akkaVersion % Provided,
   "com.typesafe.akka" %% "akka-slf4j" % akkaVersion % Provided,
   "com.typesafe.play" %% "play-json" % "2.9.2" % Provided,
   "com.typesafe.akka" %% "akka-testkit" % akkaVersion % Test,
   "org.mockito" % "mockito-all" % "1.10.19" % Test,
-  "org.scalatest" %% "scalatest" % "3.2.9" % Test,
-  "org.scalatest" %% "scalatest-mustmatchers" % "3.2.9" % Test,
-  "org.scalatest" %% "scalatest-wordspec" % "3.2.9" % Test,
+  "org.scalatest" %% "scalatest" % "3.2.10" % Test,
+  "org.scalatest" %% "scalatest-mustmatchers" % "3.2.10" % Test,
+  "org.scalatest" %% "scalatest-wordspec" % "3.2.10" % Test,
 )
 
 Compile / doc / scalacOptions ++= Seq(


### PR DESCRIPTION
- com.iheart
  - ficus (1.5.0 => 1.5.1)
- io.flow
  - lib-log (0.1.47 => 0.1.48)
- org.scalatest
  - scalatest (3.2.9 => 3.2.10)
  - scalatest-mustmatchers (3.2.9 => 3.2.10)
  - scalatest-wordspec (3.2.9 => 3.2.10)