### PR TITLE
Upgrade libraries io.flow, org.scalatest

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -25,15 +25,15 @@ lazy val akkaVersion = "2.6.17"
 
 libraryDependencies ++= Seq(
   "com.iheart" %% "ficus" % "1.5.1",
-  "io.flow" %% s"lib-log" % "0.1.61",
+  "io.flow" %% s"lib-log" % "0.1.63",
   "com.typesafe.akka" %% "akka-actor" % akkaVersion % Provided,
   "com.typesafe.akka" %% "akka-slf4j" % akkaVersion % Provided,
   "com.typesafe.play" %% "play-json" % "2.9.2" % Provided,
   "com.typesafe.akka" %% "akka-testkit" % akkaVersion % Test,
   "org.mockito" % "mockito-all" % "1.10.19" % Test,
-  "org.scalatest" %% "scalatest" % "3.2.10" % Test,
-  "org.scalatest" %% "scalatest-mustmatchers" % "3.2.10" % Test,
-  "org.scalatest" %% "scalatest-wordspec" % "3.2.10" % Test,
+  "org.scalatest" %% "scalatest" % "3.2.11" % Test,
+  "org.scalatest" %% "scalatest-mustmatchers" % "3.2.11" % Test,
+  "org.scalatest" %% "scalatest-wordspec" % "3.2.11" % Test,
 )
 
 Compile / doc / scalacOptions ++= Seq(


### PR DESCRIPTION
- io.flow
  - lib-log (0.1.61 => 0.1.63)
- org.scalatest
  - scalatest (3.2.10 => 3.2.11)
  - scalatest-mustmatchers (3.2.10 => 3.2.11)
  - scalatest-wordspec (3.2.10 => 3.2.11)