### PR TITLE
FIN-2041 Add phases to CoordinatedShutdownModule

### DIFF
--- a/src/main/scala/io/flow/akka/actor/AsReapedActor.scala
+++ b/src/main/scala/io/flow/akka/actor/AsReapedActor.scala
@@ -6,5 +6,7 @@ import akka.actor.Actor
 trait AsReapedActor {
   this: Actor =>
 
-  Reaper.get(context.system).watch(self)
+  def shutdownPhase: ManagedShutdownPhase = ManagedShutdownPhase.ServiceRequestsDone
+
+  Reaper.get(context.system).watch(self, shutdownPhase)
 }

--- a/src/main/scala/io/flow/akka/actor/ManagedShutdown.scala
+++ b/src/main/scala/io/flow/akka/actor/ManagedShutdown.scala
@@ -1,16 +1,34 @@
 package io.flow.akka.actor
 
-import akka.actor.ActorSystem
+import akka.actor.{ActorSystem, CoordinatedShutdown}
 import io.flow.util.{ShutdownNotified, Shutdownable}
+
+sealed trait ManagedShutdownPhase // Subset of service phases listed in CoordinatedShutdown
+
+object ManagedShutdownPhase {
+  case object ServiceUnbind extends ManagedShutdownPhase {
+    override def toString: String = CoordinatedShutdown.PhaseServiceUnbind
+  }
+  case object ServiceRequestsDone extends ManagedShutdownPhase {
+    override def toString: String = CoordinatedShutdown.PhaseServiceRequestsDone
+  }
+  case object ServiceStop extends ManagedShutdownPhase {
+    override def toString: String = CoordinatedShutdown.PhaseServiceStop
+  }
+
+  val All: Seq[ManagedShutdownPhase] = Seq(ServiceUnbind, ServiceRequestsDone, ServiceStop)
+}
 
 trait ManagedShutdown extends ShutdownNotified {
   self: Shutdownable =>
+
+  def shutdownPhase: ManagedShutdownPhase = ManagedShutdownPhase.ServiceRequestsDone
 
   @volatile private var shutdownState: Boolean = false
 
   def system: ActorSystem
 
-  Reaper.get(system).watch(this)
+  Reaper.get(system).watch(this, shutdownPhase)
 
   def shutdown(): Unit = {
     shutdownState = true
@@ -24,5 +42,4 @@ trait ManagedShutdown extends ShutdownNotified {
       shutdownState = true
     }
   }
-
 }

--- a/src/main/scala/io/flow/akka/actor/ReaperActor.scala
+++ b/src/main/scala/io/flow/akka/actor/ReaperActor.scala
@@ -2,7 +2,7 @@ package io.flow.akka.actor
 
 import akka.actor.{Actor, ActorLogging, ActorRef, PoisonPill, Terminated}
 
-import javax.inject.{Inject, Singleton}
+import javax.inject.Inject
 import scala.collection.mutable.{ListBuffer => MutableListBuffer}
 
 object ReaperActor {

--- a/src/main/scala/io/flow/akka/actor/ReaperActor.scala
+++ b/src/main/scala/io/flow/akka/actor/ReaperActor.scala
@@ -6,7 +6,7 @@ import javax.inject.{Inject, Singleton}
 import scala.collection.mutable.{ListBuffer => MutableListBuffer}
 
 object ReaperActor {
-  val Name: String = "flow-reaper-actor"
+  def name(phase: ManagedShutdownPhase): String = s"flow-reaper-actor-$phase"
 
   case class Watch(ref: ActorRef)
   case object Reap
@@ -15,12 +15,11 @@ object ReaperActor {
 /** Actor that watches other actors and sends them a PoisonPill when it receives a Reap message. Intended for use in
   * graceful shutdown with CoordinatedShutdown.
   */
-@Singleton
 private[actor] final class ReaperActor @Inject() (
 ) extends Actor
   with ActorLogging {
   private[this] val watchedActors = MutableListBuffer.empty[ActorRef] // Ordering is important to us
-  @volatile private[this] var stopSent: Boolean = false
+  private[this] val reapedActors = MutableListBuffer.empty[ActorRef] // Who we have sent a PoisonPill to
 
   override def receive: Receive = {
     case ReaperActor.Watch(ref) =>
@@ -33,22 +32,23 @@ private[actor] final class ReaperActor @Inject() (
     case ReaperActor.Reap =>
       if (watchedActors.isEmpty) {
         log.info("All watched actors stopped")
-        stopSent = false // for re-use within tests
         sender() ! akka.Done
       } else {
-        if (!stopSent) {
-          log.info(s"Sending stop to all (${watchedActors.size}) watched actors")
-          // Use LIFO in an attempt to unwind how the application initialized
-          watchedActors.reverse.foreach { ref =>
+        // Use LIFO in an attempt to unwind how the application initialized
+        val targets = watchedActors.filterNot(reapedActors.contains).reverse
+        if (targets.nonEmpty) {
+          log.info(s"Sending stop to (${targets.size}) watched actors")
+          targets.foreach { ref =>
             ref ! PoisonPill // Allow actors to process all messages in mailbox before stopping
+            reapedActors += ref
           }
-          stopSent = true
         }
         self forward ReaperActor.Reap
       }
 
     case Terminated(ref) =>
       watchedActors -= ref
+      reapedActors -= ref
       log.info(s"Stopped watching ${ref.path}")
   }
 }


### PR DESCRIPTION
At present, we perform all application related shutdown in a single phase.  Recently in billing we saw a jump in numbers of journal failure queue records which occurred across application deploys.  The reason always was similar to 
```
 78241349 |   57920449 | 2024-03-07 19:48:59.630264+00 | INSERT    | java.util.concurrent.ExecutionException: software.amazon.awssdk.core.exception.SdkClientException: Task java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask@56e1d1c1[Not completed, task = java.util.concurrent.Executors$RunnableAdapter@75ff88c3[Wrapped task = software.amazon.awssdk.core.internal.http.timers.AsyncTimeoutTask@7fb99cc4]] rejected from java.util.concurrent.ScheduledThreadPoolExecutor@3a4d878b[Terminated, pool size = 0, active threads = 0, queued tasks = 0, completed tasks = 7203]+| 2024-03-07 19:49:57.438823+00
```
I interpreted this as meaning that the task was rejected by an executor that had already been shut down.  The task was always related to the actor trying to publish an Upserted event to kinesis.

Thinking about this, I concluded that we need to hook into more than one phase.  Specifically
* Unbind (stop accepting new work).  For example API requests over http, consuming kinesis events (as they create work), consuming SQS messages (again creating work)
* RequestsDone (wait for current work to complete) - this is the single phase we are currently using for everything. Work is being performed in ERM processors, journal actors etc..
* Stop (final shutdown) -  Now that requests are done, we can shutdown the database, kinesis producer, SQS publisher etc.

The change in this PR adds definitions for the 3 phases.  Other PRs needed:
* lib-play: hook into 3 phases of  akkas CoordinatedShutdown instead of the 1 we currently use [[PR](https://github.com/flowcommerce/lib-play/pull/528)]
* lib-event: Change kinesis consumer to use Unbind phase, producer the Stop phase [[PR](https://github.com/flowcommerce/lib-event/pull/723)]
* lib-notification: Change SQS server actor (consumer) to Unbind, client actor (producer) to Stop [[PR](https://github.com/flowcommerce/lib-play-notification/pull/265)]
