### PR TITLE
FDN-2382: Upgrade libraries io.flow, org.scalatest

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -35,16 +35,16 @@ lazy val akkaVersion = "2.6.20"
 
 libraryDependencies ++= Seq(
   "com.iheart" %% "ficus" % "1.5.2",
-  "io.flow" %% "lib-util" % "0.2.43",
-  "io.flow" %% s"lib-log" % "0.2.21",
+  "io.flow" %% "lib-util" % "0.2.45",
+  "io.flow" %% s"lib-log" % "0.2.22",
   "com.typesafe.akka" %% "akka-actor" % akkaVersion % Provided,
   "com.typesafe.akka" %% "akka-slf4j" % akkaVersion % Provided,
   "com.typesafe.play" %% "play-json" % "2.9.4" % Provided,
   "com.typesafe.akka" %% "akka-testkit" % akkaVersion % Test,
   "org.mockito" % "mockito-all" % "1.10.19" % Test,
   "org.scalatest" %% "scalatest" % "3.2.18" % Test,
-  "org.scalatest" %% "scalatest-mustmatchers" % "3.2.18" % Test,
-  "org.scalatest" %% "scalatest-wordspec" % "3.2.18" % Test,
+  "org.scalatest" %% "scalatest-mustmatchers" % "3.2.19" % Test,
+  "org.scalatest" %% "scalatest-wordspec" % "3.2.19" % Test,
 )
 
 Test / javaOptions ++= Seq(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,7 +3,7 @@ addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat" % "0.4.1")
 
 resolvers += "Flow Plugins" at "https://flow.jfrog.io/flow/plugins-release/"
 
-addSbtPlugin("io.flow" % "sbt-flow-linter" % "0.0.56")
+addSbtPlugin("io.flow" % "sbt-flow-linter" % "0.0.57")
 
 addSbtPlugin("com.github.sbt" % "sbt-git" % "2.0.1")
 


### PR DESCRIPTION
- io.flow
  - lib-log (0.2.21 => 0.2.22)
  - lib-util (0.2.43 => 0.2.45)
  - sbt-flow-linter (0.0.56 => 0.0.57)
- org.scalatest
  - scalatest-mustmatchers (3.2.18 => 3.2.19)
  - scalatest-wordspec (3.2.18 => 3.2.19)