### PR TITLE
FDN-2627: Upgrade libraries io.flow, org.scalameta

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -36,7 +36,7 @@ lazy val akkaVersion = "2.6.20"
 libraryDependencies ++= Seq(
   "com.iheart" %% "ficus" % "1.5.2",
   "io.flow" %% "lib-util" % "0.2.50",
-  "io.flow" %% s"lib-log" % "0.2.29",
+  "io.flow" %% s"lib-log" % "0.2.31",
   "com.typesafe.akka" %% "akka-actor" % akkaVersion % Provided,
   "com.typesafe.akka" %% "akka-slf4j" % akkaVersion % Provided,
   "com.typesafe.play" %% "play-json" % "2.9.4" % Provided,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,9 +3,9 @@ addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat" % "0.4.1")
 
 resolvers += "Flow Plugins" at "https://flow.jfrog.io/flow/plugins-release/"
 
-addSbtPlugin("io.flow" % "sbt-flow-linter" % "0.0.59")
+addSbtPlugin("io.flow" % "sbt-flow-linter" % "0.0.60")
 
 addSbtPlugin("com.github.sbt" % "sbt-git" % "2.1.0")
 
-addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.2")
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.4")
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.2.2")


### PR DESCRIPTION
- io.flow
  - lib-log (0.2.29 => 0.2.31)
  - sbt-flow-linter (0.0.59 => 0.0.60)
- org.scalameta
  - sbt-scalafmt (2.5.2 => 2.5.4)