### PR TITLE
FDN-3276 Add github workflow to keep play296 branch fresh

### DIFF
--- a/.github/workflows/upsert-play296-branch.yml
+++ b/.github/workflows/upsert-play296-branch.yml
@@ -1,0 +1,33 @@
+name: Upsert play296 branch
+
+on:
+  push:
+    branches: main
+
+jobs:
+  upsert-play296-branch:
+    runs-on: ubuntu-latest
+    name: Create play296 branch or rebase it to latest main
+    steps:
+      - name: Create play296 branch (if it does not exists)
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+            gh api --silent \
+                /repos/${{ github.repository }}/git/refs \
+                -f ref="refs/heads/play296" \
+                -f sha="${{ github.sha}}" || \
+                echo 'play296 branch already exists on ${{ github.repository }}'
+      - name: Checkout play296 branch
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          ref: play296
+          fetch-depth: 0
+      - name: Rebase play296 branch to latest origin/main
+        run: |
+            git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git
+            git config --local user.email "tech@flow.io"
+            git config --local user.name "flow-tech-bot"
+            git rebase origin/main --strategy-option ours
+            git push -f -u origin play296


### PR DESCRIPTION

As main is updated, we want to keep the play296 branch up-to-date.  This PR adds a GitHub action to do just that.

<sub>This PR was generated using [turbolift](https://github.com/Skyscanner/turbolift).</sub>